### PR TITLE
Update to Travis CI (add support for java 11/13)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,19 @@
 language: java
 
-jdk:
-- oraclejdk8
-- oraclejdk7
+matrix:
+    include:
+    - name: java8
+      jdk: openjdk8
+      dist: xenial
+
+    - name: java11
+      jdk: openjdk11
+      dist: bionic
+    
+    - name: java13
+      jdk: openjdk11
+      dist: bionic
+
 
 after_success:
 - mvn clean test jacoco:report coveralls:report

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<packaging>jar</packaging>
 
 	<name>primitive-hamcrest</name>
-	<url>https://github.com/inf295uci-2015/primitive-hamcrest</url>
+	<url>https://github.com/spideruci/primitive-hamcrest</url>
 	<inceptionYear>2015</inceptionYear>
 
 	<properties>
@@ -24,8 +24,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>
-			<artifactId>java-hamcrest</artifactId>
-			<version>2.0.0.0</version>
+			<artifactId>hamcrest</artifactId>
+			<version>2.2</version>
 		</dependency>
 	</dependencies>
 
@@ -36,8 +36,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -48,7 +48,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.7.4.201502262128</version>
+				<version>0.8.5</version>
 				<executions>
 					<execution>
 						<id>prepare-agent</id>


### PR DESCRIPTION
Updated travis ci and pom (especially jacoco). Now we can compile with java 8, 11,and 13.